### PR TITLE
Fixed catch statement in Serve command to make it PHP 5.6 compatible.

### DIFF
--- a/src/Commands/Serve.php
+++ b/src/Commands/Serve.php
@@ -91,7 +91,7 @@ class Serve extends Command
                 $output->write($buffer, false, OutputInterface::OUTPUT_RAW);
             });
     }
-    catch (ProcessFailedException | Exception $e)
+    catch (Exception $e)
     {
         $this->error(sprintf(
             'Error starting the server: %s', $e->getMessage()


### PR DESCRIPTION
There was a catch statement in the Serve command class that made it PHP 5.6 incompatible. And it was reduntant nevertheless. 
`catch (ProcessFailedException | Exception $e)` is not needed, because ProcessFailedException extends RuntimeException, which extends Exception. So only:
`catch (Exception $e)` is enough, and that way makes it PHP 5.6 compatible.