### PR TITLE
Fixed sprintf() warning on migrate

### DIFF
--- a/src/Core/Migration.php
+++ b/src/Core/Migration.php
@@ -167,7 +167,7 @@ abstract class Migration extends Command
     {
         return sprintf(
             'Migrating database <info>%s</info> to version %s'
-            .'<comment>%s</comment> from <comment>%s</comment>',
+            .' from <comment>%s</comment>',
             $status, $version, $db_version
         );
     }


### PR DESCRIPTION
`sprintf()` has too few arguments so by removing `<comment>%s</comment>`  it works as it should producing the following result:

`Migrating database UP to version 20190117125722 from 0`